### PR TITLE
network - make negative scaleFactor reverse middle arrow correctly

### DIFF
--- a/lib/network/modules/components/edges/util/EdgeBase.js
+++ b/lib/network/modules/components/edges/util/EdgeBase.js
@@ -446,6 +446,7 @@ class EdgeBase {
       }
     }
 
+    if (position === 'middle' && scaleFactor < 0) lineWidth *= -1; // reversed middle arrow
     let length = 15 * scaleFactor + 3 * lineWidth; // 3* lineWidth is the width of the edge.
 
     var xi = arrowPoint.x - length * 0.9 * Math.cos(angle);


### PR DESCRIPTION
This fix makes it possible to use negative `scaleFactor` (eg. -1) to flip the middle arrow.

The bug is with this line: `15 * scaleFactor + 3 * lineWidth` - if scale factor is negative, lineWidth is applied in the wrong direction and the arrow gets smaller instead of larger.

Old behavior - wrong scaling when reversed (gets worse when selected):
![screenshot_20170922_120556](https://user-images.githubusercontent.com/2041118/30739825-020245d0-9f8f-11e7-8822-e591618e99a7.png)
![screenshot_20170922_120606](https://user-images.githubusercontent.com/2041118/30739831-054a2ce4-9f8f-11e7-9b77-4259e1c5700a.png)

New behavior - scales correctly
![screenshot_20170922_120703](https://user-images.githubusercontent.com/2041118/30739842-0ae0700a-9f8f-11e7-8519-b45388ad5d1e.png)

